### PR TITLE
create 0.5.1.e compat

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -158,7 +158,7 @@ dependencies {
     // implementation fg.deobf("blank:coolmod-${mc_version}:${coolmod_version}")
     implementation fg.deobf("com.simibubi.create:create-${create_minecraft_version}:${create_version}:slim") { transitive = false }
     implementation fg.deobf("com.jozufozu.flywheel:flywheel-forge-${flywheel_minecraft_version}:${flywheel_version}")
-    implementation  fg.deobf("com.tterrag.registrate:Registrate:${registrate_version}")
+    implementation fg.deobf("com.tterrag.registrate:Registrate:${registrate_version}")
 
     compileOnly fg.deobf("mezz.jei:jei-${jei_minecraft_version}-common-api:${jei_version}")
     compileOnly fg.deobf("mezz.jei:jei-${jei_minecraft_version}-forge-api:${jei_version}")

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,7 +4,7 @@ org.gradle.jvmargs=-Xmx3G
 org.gradle.daemon=false
 
 # mod version info
-mod_version = 1.2.2
+mod_version = 1.2.3
 artifact_minecraft_version = 1.19.2
 minecraft_version = 1.19.2
 forge_version = 43.2.4
@@ -18,9 +18,9 @@ parchment_version = 2022.11.06
 
 # dependency versions
 create_minecraft_version = 1.19.2
-create_version = 0.5.1.a-29
+create_version = 0.5.1.e-44
 flywheel_minecraft_version = 1.19.2
-flywheel_version = 0.6.8.a-14
+flywheel_version = 0.6.10-20
 registrate_version = MC1.19-1.1.5
 jei_minecraft_version = 1.19.2
 jei_version = 11.2.0.254

--- a/src/main/java/plus/dragons/createdragonlib/advancement/critereon/SimpleTrigger.java
+++ b/src/main/java/plus/dragons/createdragonlib/advancement/critereon/SimpleTrigger.java
@@ -1,7 +1,6 @@
 package plus.dragons.createdragonlib.advancement.critereon;
 
 import com.google.gson.JsonObject;
-import com.simibubi.create.foundation.advancement.ITriggerable;
 import net.minecraft.advancements.critereon.DeserializationContext;
 import net.minecraft.advancements.critereon.EntityPredicate;
 import net.minecraft.resources.ResourceLocation;
@@ -11,7 +10,7 @@ import javax.annotation.Nullable;
 import java.util.List;
 import java.util.function.Supplier;
 
-public class SimpleTrigger extends AbstractTrigger<SimpleTrigger.Instance> implements ITriggerable {
+public class SimpleTrigger extends AbstractTrigger<SimpleTrigger.Instance> {
 
     public SimpleTrigger(ResourceLocation id) {
         super(id);

--- a/src/main/java/plus/dragons/createdragonlib/lang/LangFactory.java
+++ b/src/main/java/plus/dragons/createdragonlib/lang/LangFactory.java
@@ -61,6 +61,7 @@ public class LangFactory {
      *                   in most cases you should force bootstrap your ponders here.
      * @return self
      */
+    // FIXME :: record() is deprecated and will be removed
     public LangFactory ponders(Runnable preTask) {
         langMerger.partials.add(new LangPartial.Gen(
             modid,


### PR DESCRIPTION
The incompatibility is basically just the removal of the interface `com/simibubi/create/foundation/advancement/ITriggerable` in https://github.com/Creators-of-Create/Create/commit/4cda09e0e7ee64ab03223215ecfd833e012ad7c4

There is one `deprecated` entry now though (for `LangFactory#ponders`)
But I don't know enough about that set up to change it atm

Advancements still work:

(Tested with ore and crushing wheels)
![image](https://github.com/DragonsPlusMinecraft/CreateDragonLib/assets/22003703/a6b9f181-0616-4e0e-ade1-673337603003)

Changes to `Create Enchantment Industry`:

gradle.properties

``` properties
# Gradle
org.gradle.jvmargs=-Xmx3G
org.gradle.daemon=false

# Mod Versions
mod_version = 1.2.6.c # updated
artifact_minecraft_version = 1.19.2
minecraft_version = 1.19.2
forge_version = 43.2.4

# Build Dependency Versions
forgegradle_version = 5.1.73
mixingradle_version = 0.7-SNAPSHOT
mixin_version = 0.8.5
librarian_version = 1.+
parchment_version = 2022.11.27

# Dependency Versions
create_minecraft_version = 1.19.2
create_version = 0.5.1.e # updated
create_version_build = 44 # updated
flywheel_minecraft_version = 1.19.2
flywheel_version = 0.6.10-20 # updated
registrate_version = MC1.19-1.1.5
create_dragon_lib_version = 1.2.3 # updated
create_dragon_lib_version_range = [1.2.0, 1.3.0)
jei_minecraft_version = 1.19.2
jei_version = 11.2.0.254
curios_minecraft_version = 1.19.2
curios_version = 5.1.1.0
```